### PR TITLE
Fix build error that's excluding NestedModules from module manifest file

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -46,6 +46,11 @@ $manifestPath = "$publishOutputDir\WhatsNew.psd1"
 
 $newManifestArgs = @{
   Path = $manifestPath
+}
+
+$updateManifestArgs = @{
+  Path = $manifestPath
+  CopyRight = "(c) $((Get-Date).Year) Nick Spreitzer"
   Description = "Powershell functions for versioning a git repo with tags and more!"
   Guid = '861e5d28-8348-47d3-a2f6-cdd23e33bb55'
   Author = 'Nick Spreitzer'
@@ -55,10 +60,9 @@ $newManifestArgs = @{
   NestedModules = $modules
   CmdletsToExport = $cmdletNames
   FunctionsToExport = $scriptFunctions
-}
-
-$updateManifestArgs = @{
-  Path = $manifestPath
+  CompatiblePSEditions = @("Desktop","Core")
+  HelpInfoUri = "https://github.com/refactorsaurusrex/whats-new/wiki"
+  PowerShellVersion = "6.0"
   PrivateData = @{
     Tags = 'git','semver'
     LicenseUri = 'https://github.com/refactorsaurusrex/whats-new/blob/master/LICENSE.md'


### PR DESCRIPTION
The build was calling `New-ModuleManifest` to create an initial manifest file, then immediately calling `Update-ModuleManifest` to add `PrivateData` properties. The only reason for this was because the output of `New-ModuleManifest` is incorrect due to a known bug. Well, it turns out that `Update-ModuleManifest` has a problem where it removes the `NestedModules` property from the original manifest file. To fix this, the build only uses `New-ModuleManifest` to create the file. All manifest properties are then added to the file via `Update-ModuleManifest`. This seems to resolve the problems encountered.