### PR TITLE
Release: Version 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ $newManifestArgs = @{
 New-ModuleManifest @newManifestArgs
 ```
 
+## Create a Table of Contents
+
+...for your GitHub wiki home page, [just like this](https://github.com/refactorsaurusrex/whats-new/wiki#list-of-all-available-commands) with the [New-MarkdownTableOfContents](https://github.com/refactorsaurusrex/whats-new/wiki/New-MarkdownTableOfContents) cmdlet.
+
+**Pro Tip:** Install [ClipboardText](https://www.powershellgallery.com/packages/ClipboardText) to pipe your ToC right to your clipboard. 
+
+## Make Yaml Front Matter Pretty on GitHub
+
+If you happen to use [platyPS](https://github.com/PowerShell/platyPS) to create markdown documentation for PowerShell modules (as I do), you may have noticed that the metadata platyPS emits as yaml front matter doesn't render all that nicely on GitHub. Use [Switch-YamlFrontMatterToCodeFence](https://github.com/refactorsaurusrex/whats-new/wiki/Switch-YamlFrontMatterToCodeFence) to make it pretty on GitHub and [Switch-CodeFenceToYamlFrontMatter](https://github.com/refactorsaurusrex/whats-new/wiki/Switch-CodeFenceToYamlFrontMatter) to switch it back as needed. 
+
 # Installation
 
 Get it from the [PowerShell Gallery](https://www.powershellgallery.com/packages/WhatsNew): 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.0.{build}
+version: 3.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 branches:

--- a/build.ps1
+++ b/build.ps1
@@ -21,11 +21,6 @@ if ($LASTEXITCODE -ne 0) {
   throw "Failed to publish application."
 }
 
-Get-ChildItem -Filter "WhatsNew.dll-Help.xml" -Recurse -File -Path "$PSScriptRoot\src" |
-  Where-Object { $_.FullName -like "*bin\Release*" } | 
-  Select-Object -First 1 | 
-  Copy-Item -Destination $publishOutputDir -Force
-
 Remove-Item "$publishOutputDir\*.pdb"
 
 Import-Module "$publishOutputDir\WhatsNew.dll"
@@ -77,3 +72,16 @@ Remove-ModuleManifestComments $manifestPath -NoConfirm
 
 New-item -ItemType Directory -Path "$publishOutputDir\script-modules\" | Out-Null
 Get-ChildItem -Path "$PSScriptRoot\src\script-modules" -Filter "*.ps*1" | Copy-Item -Destination "$publishOutputDir\script-modules\"
+
+Install-Module platyPS
+Import-Module platyPS
+$docs = "$PSScriptRoot\docs"
+try {
+  git clone https://github.com/refactorsaurusrex/whats-new.wiki.git $docs
+  Switch-CodeFenceToYamlFrontMatter -Path $docs -NoConfirm
+  New-ExternalHelp -Path $docs -OutputPath $publishOutputDir
+} finally {
+  if (Test-Path $docs) {
+    Remove-Item -Path $docs -Recurse -Force
+  }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -59,7 +59,7 @@ $updateManifestArgs = @{
   HelpInfoUri = "https://github.com/refactorsaurusrex/whats-new/wiki"
   PowerShellVersion = "6.0"
   PrivateData = @{
-    Tags = 'git','semver'
+    Tags = 'git','semver', 'markdown'
     LicenseUri = 'https://github.com/refactorsaurusrex/whats-new/blob/master/LICENSE.md'
     ProjectUri = 'https://github.com/refactorsaurusrex/whats-new'
   }

--- a/src/WhatsNew/ExportBinaryCmdletAliasesCmdlet.cs
+++ b/src/WhatsNew/ExportBinaryCmdletAliasesCmdlet.cs
@@ -5,22 +5,13 @@ using JetBrains.Annotations;
 
 namespace WhatsNew
 {
-    /// <summary>
-    /// <para type="synopsis">Extracts cmdlet aliases from a given module.</para>
-    /// <para type="description">Returns a list of all cmdlet aliases contained within a specified binary cmdlet module.</para>
-    /// <para type="link" uri="https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#export-binarycmdletaliases">Online help.</para>
-    /// </summary>
     [PublicAPI]
     [Cmdlet(VerbsData.Export, "BinaryCmdletAliases")]
     public class ExportBinaryCmdletAliasesCmdlet : PSCmdlet
     {
-        /// <summary>
-        /// <para type="description">The PSModuleInfo from which to extract cmdlet names</para>
-        /// </summary>
         [Parameter(ValueFromPipeline = true, Mandatory = true)]
         public PSModuleInfo ModuleInfo { get; set; }
 
-        /// <inheritdoc />
         protected override void ProcessRecord()
         {
             if (ModuleInfo.ModuleType != ModuleType.Binary)

--- a/src/WhatsNew/ExportBinaryCmdletNamesCmdlet.cs
+++ b/src/WhatsNew/ExportBinaryCmdletNamesCmdlet.cs
@@ -5,22 +5,13 @@ using JetBrains.Annotations;
 
 namespace WhatsNew
 {
-    /// <summary>
-    /// <para type="synopsis">Extracts cmdlet names from a given module.</para>
-    /// <para type="description">Returns a list of all cmdlet names contained within a specified binary cmdlet module.</para>
-    /// <para type="link" uri="https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#export-binarycmdletnames">Online help.</para>
-    /// </summary>
     [PublicAPI]
     [Cmdlet(VerbsData.Export, "BinaryCmdletNames")]
     public class ExportBinaryCmdletNamesCmdlet : PSCmdlet
     {
-        /// <summary>
-        /// <para type="description">The PSModuleInfo from which to extract cmdlet names</para>
-        /// </summary>
         [Parameter(ValueFromPipeline = true, Mandatory = true)]
         public PSModuleInfo ModuleInfo { get; set; }
 
-        /// <inheritdoc />
         protected override void ProcessRecord()
         {
             if (ModuleInfo.ModuleType != ModuleType.Binary)

--- a/src/WhatsNew/ExportPSScriptAliasesCmdlet.cs
+++ b/src/WhatsNew/ExportPSScriptAliasesCmdlet.cs
@@ -5,22 +5,14 @@ using JetBrains.Annotations;
 
 namespace WhatsNew
 {
-    /// <summary>
-    /// <para type="synopsis">Extracts aliases from a given PowerShell script.</para>
-    /// <para type="description">Returns a list of all aliases contained within a specified PowerShell script.</para>
-    /// <para type="link" uri="https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#export-psscriptaliases">Online help.</para>
-    /// </summary>
     [PublicAPI]
     [Cmdlet(VerbsData.Export, "PSScriptAliases")]
+    [OutputType(typeof(string[]))]
     public class ExportPSScriptAliasesCmdlet : PSCmdlet
     {
-        /// <summary>
-        /// <para type="description">The PowerShell script file from which to extract all function names.</para>
-        /// </summary>
         [Parameter(ValueFromPipeline = true, Mandatory = true)]
         public string ScriptFile { get; set; }
 
-        /// <inheritdoc />
         protected override void ProcessRecord()
         {
             var scriptBlockAst = Parser.ParseFile(ScriptFile, out _, out _);

--- a/src/WhatsNew/ExportPSScriptFunctionNamesCmdlet.cs
+++ b/src/WhatsNew/ExportPSScriptFunctionNamesCmdlet.cs
@@ -5,22 +5,13 @@ using JetBrains.Annotations;
 
 namespace WhatsNew
 {
-    /// <summary>
-    /// <para type="synopsis">Extracts function names from a given PowerShell script.</para>
-    /// <para type="description">Returns a list of all function names contained within a specified PowerShell script.</para>
-    /// <para type="link" uri="https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#export-psscriptfunctionnames">Online help.</para>
-    /// </summary>
     [PublicAPI]
     [Cmdlet(VerbsData.Export, "PSScriptFunctionNames")]
     public class ExportPSScriptFunctionNamesCmdlet : PSCmdlet
     {
-        /// <summary>
-        /// <para type="description">The PowerShell script file from which to extract all function names.</para>
-        /// </summary>
         [Parameter(ValueFromPipeline = true, Mandatory = true)]
         public string ScriptFile { get; set; }
 
-        /// <inheritdoc />
         protected override void ProcessRecord()
         {
             var scriptBlockAst = Parser.ParseFile(ScriptFile, out var tokens, out var errors);

--- a/src/WhatsNew/Extensions.cs
+++ b/src/WhatsNew/Extensions.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace WhatsNew
+{
+    internal static class Extensions
+    {
+        public static bool YamlFrontMatterToCodeFence(this List<string> markdownLines)
+        {
+            if (markdownLines.First() != "---")
+                return false;
+
+            var counter = 0;
+            for (var i = 0; i < markdownLines.Count; i++)
+            {
+                if (markdownLines[i].StartsWith("---"))
+                {
+                    markdownLines[i] = markdownLines[i].Replace("---", "```");
+                    if (++counter >= 2)
+                        break;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool CodeFenceToYamlFrontMatter(this List<string> value)
+        {
+            if (value.First() != "```")
+                return false;
+
+            var counter = 0;
+            for (var i = 0; i < value.Count; i++)
+            {
+                if (value[i].StartsWith("```"))
+                {
+                    value[i] = value[i].Replace("```", "---");
+                    if (++counter >= 2)
+                        break;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/WhatsNew/NewMarkdownTableOfContentsCmdlet.cs
+++ b/src/WhatsNew/NewMarkdownTableOfContentsCmdlet.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using System.Text;
+using JetBrains.Annotations;
+using Flurl;
+
+namespace WhatsNew
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.New, "MarkdownTableOfContents")]
+    [OutputType(typeof(string))]
+    public class NewMarkdownTableOfContentsCmdlet : PSCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Path { get; set; }
+
+        [Parameter(Mandatory = true, Position = 1)]
+        public string Filter { get; set; }
+
+        [Parameter(Mandatory = true, Position = 2)]
+        public string BaseUrl { get; set; }
+
+        [Parameter(Position = 3)]
+        [ValidateSet("Ordered", "Unordered", IgnoreCase = true)]
+        public string ListType { get; set; } = "Unordered";
+
+        protected override void ProcessRecord()
+        {
+            Path = GetUnresolvedProviderPathFromPSPath(Path);
+            var builder = new StringBuilder();
+            var dir = new DirectoryInfo(Path);
+            var files = dir.GetFiles(Filter, SearchOption.AllDirectories);
+            var listMarker = ListType == "Unordered" ? "-" : "1.";
+
+            foreach (var file in files.OrderBy(f => f.Name))
+            {
+                var uri = BaseUrl.AppendPathSegment(System.IO.Path.GetFileNameWithoutExtension(file.FullName));
+                builder.Append($"{listMarker} [{System.IO.Path.GetFileNameWithoutExtension(file.FullName)}]({uri}){Environment.NewLine}");
+            }
+
+            WriteObject(builder.ToString());
+        }
+    }
+}

--- a/src/WhatsNew/Properties/launchSettings.json
+++ b/src/WhatsNew/Properties/launchSettings.json
@@ -3,8 +3,8 @@
     "WhatsNew": {
       "commandName": "Executable",
       "executablePath": "C:\\Program Files\\PowerShell\\6\\pwsh.exe",
-      "commandLineArgs": "-NoExit -NoLogo -NoProfile -Command \"Import-Module .\\publish\\WhatsNew.dll\"",
-      "workingDirectory": "c:\\repos\\whats-new"
+      "commandLineArgs": "-NoExit -NoLogo -NoProfile -Command \"Import-Module .\\WhatsNew.dll\"",
+      "workingDirectory": "c:\\repos\\whats-new\\publish\\WhatsNew"
     }
   }
 }

--- a/src/WhatsNew/SwitchCodeFenceToYamlFrontMatterCmdlet.cs
+++ b/src/WhatsNew/SwitchCodeFenceToYamlFrontMatterCmdlet.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
+using JetBrains.Annotations;
+
+namespace WhatsNew
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Switch, "CodeFenceToYamlFrontMatter", ConfirmImpact = ConfirmImpact.High)]
+    public class SwitchCodeFenceToYamlFrontMatterCmdlet : PSCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Path { get; set; }
+
+        [Parameter]
+        public SwitchParameter NoConfirm { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            Path = GetUnresolvedProviderPathFromPSPath(Path);
+
+            if (File.Exists(Path))
+            {
+                var warning = $"You're about to convert a code fence in the following file to yaml front matter.{Environment.NewLine}{Path}";
+                if (!NoConfirm && !ShouldContinue("Do you want to continue?", warning)) return;
+
+                var lines = File.ReadAllLines(Path).ToList();
+                if (lines.CodeFenceToYamlFrontMatter())
+                    File.WriteAllLines(Path, lines);
+            }
+            else if (Directory.Exists(Path))
+            {
+                var warning = $"You're about to convert a code fence to yaml front matter in all markdown files in the following directory.{Environment.NewLine}{Path}";
+                if (!NoConfirm && !ShouldContinue("Do you want to continue?", warning)) return;
+
+                foreach (var file in Directory.GetFiles(Path, "*.md", SearchOption.AllDirectories))
+                {
+                    var lines = File.ReadAllLines(file).ToList();
+                    if (lines.CodeFenceToYamlFrontMatter())
+                        File.WriteAllLines(file, lines);
+                }
+            }
+            else
+            {
+                throw new PSArgumentException("The specified path does not exist.");
+            }
+        }
+    }
+}

--- a/src/WhatsNew/SwitchYamlFrontMatterToCodeFenceCmdlet.cs
+++ b/src/WhatsNew/SwitchYamlFrontMatterToCodeFenceCmdlet.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Management.Automation;
+using JetBrains.Annotations;
+using System.Linq;
+
+namespace WhatsNew
+{
+    [PublicAPI]
+    [Cmdlet(VerbsCommon.Switch, "YamlFrontMatterToCodeFence", ConfirmImpact = ConfirmImpact.High)]
+    public class SwitchYamlFrontMatterToCodeFenceCmdlet : PSCmdlet
+    {
+        [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string Path { get; set; }
+
+        [Parameter]
+        public SwitchParameter NoConfirm { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            Path = GetUnresolvedProviderPathFromPSPath(Path);
+
+            if (File.Exists(Path))
+            {
+                var warning = $"You're about to convert the yaml front matter in the following file to a code fence.{Environment.NewLine}{Path}";
+                if (!NoConfirm && !ShouldContinue("Do you want to continue?", warning)) return;
+
+                var lines = File.ReadAllLines(Path).ToList();
+                if (lines.YamlFrontMatterToCodeFence())
+                    File.WriteAllLines(Path, lines);
+            }
+            else if (Directory.Exists(Path))
+            {
+                var warning = $"You're about to convert the yaml front matter to a code fence in all markdown files in the following directory.{Environment.NewLine}{Path}";
+                if (!NoConfirm && !ShouldContinue("Do you want to continue?", warning)) return;
+
+                foreach (var file in Directory.GetFiles(Path, "*.md", SearchOption.AllDirectories))
+                {
+                    var lines = File.ReadAllLines(file).ToList();
+                    if (lines.YamlFrontMatterToCodeFence())
+                        File.WriteAllLines(file, lines);
+                }
+            }
+            else
+            {
+                throw new PSArgumentException("The specified path does not exist.");
+            }
+        }
+    }
+}

--- a/src/WhatsNew/WhatsNew.csproj
+++ b/src/WhatsNew/WhatsNew.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Flurl" Version="2.8.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="XmlDoc2CmdletDoc" Version="0.2.12">

--- a/src/WhatsNew/WhatsNew.csproj
+++ b/src/WhatsNew/WhatsNew.csproj
@@ -6,11 +6,11 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <NoWarn></NoWarn>
-    <DocumentationFile>C:\Repos\whats-new\src\WhatsNew\WhatsNew.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\Repos\whats-new\src\WhatsNew\WhatsNew.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <NoWarn>1701;1702</NoWarn>
   </PropertyGroup>
 
@@ -26,16 +26,12 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl" Version="2.8.2" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
-    <PackageReference Include="XmlDoc2CmdletDoc" Version="0.2.12">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="if $(ConfigurationName) == Debug (&#xD;&#xA;  dotnet publish --no-build --output $(SolutionDir)..\publish&#xD;&#xA;  xcopy $(OutDir)$(ProjectName).dll-Help.xml $(SolutionDir)..\publish /y&#xD;&#xA;)" />
+    <Exec Command="if $(ConfigurationName) == Debug (&#xD;&#xA;  dotnet publish --no-build --output $(SolutionDir)..\publish\$(ProjectName)&#xD;&#xA;)" />
   </Target>
 
 </Project>

--- a/src/script-modules/GitVersioning.psm1
+++ b/src/script-modules/GitVersioning.psm1
@@ -47,7 +47,7 @@ function New-VersionTag {
     throw "$Tag is not a valid version number. Use the format 'v1.2.3'."
   }
 
-  git tag -a $NewTag -m $Message 
+  git tag -a $Tag -m $Message 
   Write-Host "New tag created`: $Tag $Message" -ForegroundColor Cyan
 }
 

--- a/src/script-modules/GitVersioning.psm1
+++ b/src/script-modules/GitVersioning.psm1
@@ -1,16 +1,3 @@
-<# 
-.SYNOPSIS
-  Adds a new major version tag to the current git repository.
-.DESCRIPTION
-  Finds the most recent semantic version tag in the current git repository, increments the major version, and creates
-  a new tag based on this new version. 
-.PARAMETER Message
-  The message to associate with the new tag.
-.PARAMETER CurrentBranchOnly
-  Restricts the search for prior version tags to the current branch. By default all branches are searched.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#add-majorversiontag
-#>
 function Add-MajorVersionTag {
   Param (
     [Parameter(Mandatory = $true, Position = 0)][string]$Message,
@@ -24,19 +11,6 @@ function Add-MajorVersionTag {
   WriteSuccessMessage $($elements[3]) $NewTag $Message
 }
 
-<# 
-.SYNOPSIS
-  Adds a new minor version tag to the current git repository.
-.DESCRIPTION
-  Finds the most recent semantic version tag in the current git repository, increments the minor version, and creates
-  a new tag based on this new version. 
-.PARAMETER Message
-  The message to associate with the new tag.
-.PARAMETER CurrentBranchOnly
-  Restricts the search for prior version tags to the current branch. By default all branches are searched.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#add-minorversiontag
-#>
 function Add-MinorVersionTag {
   Param (
     [Parameter(Mandatory = $true, Position = 0)][string]$Message,
@@ -50,19 +24,6 @@ function Add-MinorVersionTag {
   WriteSuccessMessage $($elements[3]) $NewTag $Message
 }
 
-<# 
-.SYNOPSIS
-  Adds a new patch version tag to the current git repository.
-.DESCRIPTION
-  Finds the most recent semantic version tag in the current git repository, increments the patch version, and creates
-  a new tag based on this new version. 
-.PARAMETER Message
-  The message to associate with the new tag.
-.PARAMETER CurrentBranchOnly
-  Restricts the search for prior version tags to the current branch. By default all branches are searched.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#add-patchversiontag
-#>
 function Add-PatchVersionTag {
   Param (
     [Parameter(Mandatory = $true, Position = 0)][string]$Message,
@@ -76,18 +37,6 @@ function Add-PatchVersionTag {
   WriteSuccessMessage $($elements[3]) $NewTag $Message
 }
 
-<# 
-.SYNOPSIS
-  Adds a new semantic version tag to the current git repository.
-.DESCRIPTION
-  Creates a new semantic version tag to the current git respository based on the provided version string.
-.PARAMETER Tag
-  The new semantic version tag to apply. Must be in the format 'v0.0.0'.
-.PARAMETER Message
-  The message to associate with the new tag.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#new-versiontag
-#>
 function New-VersionTag {
   Param (
     [Parameter(Mandatory = $true, Position = 0)][string]$Tag,

--- a/src/script-modules/OpenSolution.psm1
+++ b/src/script-modules/OpenSolution.psm1
@@ -1,13 +1,3 @@
-<#
-.SYNOPSIS
-  Opens a `.sln` file in the default editor.
-.DESCRIPTION
-  Recursively searches for the first `.sln` file and opens it using the default application, usually Visual Studio. 
-.PARAMETER RootDirectory
-  The directory to search. Defaults to the current directory. 
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#open-solution
-#>
 function Open-Solution {
   [Alias('sln')]
   param (

--- a/src/script-modules/RemoveLocalBranches.psm1
+++ b/src/script-modules/RemoveLocalBranches.psm1
@@ -1,14 +1,3 @@
-<#
-.SYNOPSIS
-  Deletes all local git branches in the current respository, other than master.
-.DESCRIPTION
-  Deletes all local git branches in the current respository, other than master. By default, unmerged branches
-  are ignored. Use -Force to delete all non-master branches regardless of merge status.
-.PARAMETER Force
-  Deletes all braches regardless of merge status.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#remove-localbranches
-#>
 function Remove-LocalBranches ([switch]$Force) {
   git branch |
     Where-Object { $_ -notmatch '(^\*)|(^. master$)' } |

--- a/src/script-modules/RemoveModuleManifestComments.psm1
+++ b/src/script-modules/RemoveModuleManifestComments.psm1
@@ -1,18 +1,3 @@
-<#
-.SYNOPSIS
-  Removes comments from module manifest files.
-.DESCRIPTION
-  When you use the New-ModuleManifest cmdlet to create a module manifest, it generates a lot of comments that you may not want to keep. This
-  function strips away that noise and makes your manifest easy to read.
-.INPUTS
-  You can pipe ine a string containing the file path of a PowerShell module manifest file.
-.PARAMETER ManifestPath
-  The path to the module manifest file.
-.PARAMETER NoConfirm
-  Do not confirm before overwriting the manifest file.
-.LINK
-  https://github.com/refactorsaurusrex/whats-new/wiki/Cmdlet-and-Function-Overview#remove-modulemanifestcomments
-#>
 function Remove-ModuleManifestComments {
   [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
   param (


### PR DESCRIPTION
- Added new cmdlet that generates a markdown-based table of contents, primarily for GitHub wikis.
- Added new cmdlet to switch yaml front matter to markdown code fences and back.
- Removed all comment based documentation to dedicated markdown files, as generated by platyPS.
- Fixed bug in GitVersioning module which prevented `New-VersionTag` from working correctly.